### PR TITLE
Add citation-js fallback to Citoid service

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,12 @@
 	},
 	"dependencies": {
 		"@citation-js/date": "^0.5.1",
-		"@citation-js/plugin-bibtex": "^0.5.0",
+		"@citation-js/plugin-bibtex": "^0.7.21",
+		"@citation-js/plugin-isbn": "^0.4.0",
+		"@citation-js/plugin-doi": "^0.7.21",
+		"@citation-js/plugin-pubmed": "^0.3.0",
+		"@citation-js/plugin-wikidata": "^0.7.21",
 		"buffer": "^6.0.3",
-		"citation-js": "^0.5.0"
+		"citation-js": "^0.7.21"
 	}
 }

--- a/src/ui/modals/bibliography-modal.ts
+++ b/src/ui/modals/bibliography-modal.ts
@@ -257,7 +257,7 @@ export class BibliographyModal extends Modal {
         // Create identifier field
         const citoidIdSetting = new Setting(citoidContent)
             .setName('Auto-lookup by identifier')
-            .setDesc('DOI, ISBN, arXiv ID, URL');
+            .setDesc('DOI, ISBN, arXiv ID, URL, PubMed, PMC, Wikidata QIDs');
         
         const citoidIdInput = citoidIdSetting.controlEl.createEl('input', {
             type: 'text',


### PR DESCRIPTION
Citoid no longer has WorldCat API access, resulting in coverage gaps. Some books, such as 978-3-7306-0805-0, are not available through the API endpoint:
https://en.wikipedia.org/api/rest_v1/data/citation/bibtex/978-3-7306-0805-0.
This pull request adds a fallback to the Citoid service using citation-js, which relies on Google APIs. Additionally, it adds support for PubMed, PMC, and Wikidata QIDs. Feel free to remove those if you find them unnecessary.