### PR TITLE
WIP: Fix Zotero Connector not opening modal for PubMed and PMC articles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-biblib",
-	"version": "1.7.2",
+	"version": "1.8.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-biblib",
-			"version": "1.7.2",
+			"version": "1.8.0",
 			"license": "MIT",
 			"dependencies": {
 				"@citation-js/date": "^0.5.1",
@@ -1629,9 +1629,9 @@
 			}
 		},
 		"node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1935,9 +1935,9 @@
 			}
 		},
 		"node_modules/@jest/reporters/node_modules/glob": {
-			"version": "10.4.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3127,6 +3127,19 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/anymatch/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3280,9 +3293,9 @@
 			"optional": true
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5357,9 +5370,9 @@
 			}
 		},
 		"node_modules/jest-config/node_modules/glob": {
-			"version": "10.4.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -5690,9 +5703,9 @@
 			}
 		},
 		"node_modules/jest-runtime/node_modules/glob": {
-			"version": "10.4.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -5775,19 +5788,6 @@
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-			}
-		},
-		"node_modules/jest-util/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/jest-validate": {
@@ -6170,6 +6170,18 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/micromatch/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/mimic-fn": {
@@ -6643,12 +6655,13 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8.6"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
@@ -7332,19 +7345,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/SuperchupuDev"
-			}
-		},
-		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/tmp": {

--- a/src/managers/zotero-connector-manager.ts
+++ b/src/managers/zotero-connector-manager.ts
@@ -215,7 +215,7 @@ export class ZoteroConnectorManager {
             new Notice('Invalid Zotero item received');
             console.error('Invalid Zotero item data in event detail:', event.detail);
             return;
-        }
+		}
 
         const itemId = item.id || 'unknown';
         
@@ -335,10 +335,10 @@ export class ZoteroConnectorManager {
      */
     private processZoteroAttachments(files: any[], modal: BibliographyModal): void {
         // Process attachments if we have any
-        if (!files || !Array.isArray(files) || files.length === 0) {
+		if (!files || !Array.isArray(files) || files.length === 0) {
             return;
-        }
-        
+		}
+
         let attachmentsAdded = 0;
         
         // Track already processed attachments to prevent duplicates
@@ -378,6 +378,7 @@ export class ZoteroConnectorManager {
                 }
                 // If 'files' contains paths (requires Node 'fs' on desktop):
                 else if (typeof filePath === 'string' && !Platform.isMobile) {
+					// eslint-disable-next-line @typescript-eslint/no-require-imports
                     const fs = require('fs');
                     if (fs.existsSync(filePath)) {
                         const fileName = filePath.split(/[/\\]/).pop() || 'document.pdf';
@@ -425,8 +426,8 @@ export class ZoteroConnectorManager {
      * This is specifically for slow-loading attachments like PDFs
      */
     private handleAdditionalAttachments(event: CustomEvent): void {
-        const { itemId, files, sessionID } = event.detail;
-        
+		const { itemId, files } = event.detail;
+
         if (!files || !Array.isArray(files) || files.length === 0) {
             return;
         }


### PR DESCRIPTION
Fix modal not opening for PMC/PubMed articles due to attachment ID mismatch

- Add session completion logic to handle Zotero dynamically
replacing attachments
- Implement orphan attachment detection for when expected attachment
IDs never arrive
- Add logic to detect when PDF attachments replace lower-quality HTML
attachments
- Set 3-second completion timeout for improved responsiveness

From what I could tell, the core issue was that Zotero initially reports HTML snapshots or
"Catalog Page" attachments, but then dynamically replaces them
with actual PDF attachments that have different attachment IDs.

The original implementation would hang indefinitely waiting for
attachment IDs that would never arrive.

Resolves modal opening issues for PMC articles where PDFs are
automatically discovered as secondary attachments,
and PubMed articles with similar attachment ID mismatches.

> [!WARNING]
> Tests pass, but I only tested with PMC and PubMed. Does not fix undetected PDF for PubMed - that's an issue with the browser extension and/or Unpaywall and other tooling used by the browser extension (Zotero translators?). 
> Improves "directory" handling for [DTU findit](https://findit.dtu.dk/), but can only open the modal if saving from Zotero connector with "Web Page with Snapshot". Not sure this has to do with the changes in this PR or some translators being updated?

Fixes (partially) https://github.com/callumalpass/obsidian-biblib/issues/26