### PR TITLE
Fix bibliography modal citekey generation

### DIFF
--- a/src/services/note-creation-service.ts
+++ b/src/services/note-creation-service.ts
@@ -282,7 +282,11 @@ export class NoteCreationService {
 	          if (importSettings.citekeyPreference === 'imported' && importedCitekey) {
 	            citekey = importedCitekey;
           } else {
-            citekey = CitekeyGenerator.generate(parsedRef.cslData, this.settings.citekeyOptions);
+            // remove the ID. otherwise the imported key always wins even if the user
+			// used importSettings.citekeyPreference to generate instead of use imported
+            const cslDataForGeneration = { ...parsedRef.cslData };
+            delete cslDataForGeneration.id;
+            citekey = CitekeyGenerator.generate(cslDataForGeneration, this.settings.citekeyOptions);
           }
           
           // Sanitize citekey

--- a/src/ui/modals/bibliography-modal.ts
+++ b/src/ui/modals/bibliography-modal.ts
@@ -535,11 +535,6 @@ export class BibliographyModal extends BaseBibliographyModal {
                 this.idInput.value = id;
             }
             
-            // Auto-generate ID if not present but we have author and year
-            if (!id && (cslData.author || cslData.issued)) {
-                const citekey = CitekeyGenerator.generate(cslData, this.settings.citekeyOptions);
-                this.idInput.value = citekey;
-            }
             
             // Type dropdown - find closest match to CSL type
             const cslType = getString(cslData, 'type');
@@ -684,6 +679,12 @@ export class BibliographyModal extends BaseBibliographyModal {
                 }
             }
             
+            // Auto-generate ID only after the other information got  brought in
+            if (!this.idInput.value) {
+                const generatedId = CitekeyGenerator.generate(cslData, this.settings.citekeyOptions);
+                this.idInput.value = generatedId;
+            }
+            
         } catch (error) {
             console.error('Error populating form from CSL data:', error);
             new Notice('Error populating form. Some fields may be incomplete.');
@@ -786,10 +787,7 @@ export class BibliographyModal extends BaseBibliographyModal {
     protected getFormValues(): Citation {
         // Build citation object from form fields
         const citation: Citation = {
-            id: this.idInput.value || CitekeyGenerator.generate({ 
-                title: this.titleInput.value,
-                author: this.contributors.filter(c => c.role === 'author')
-            }, this.settings.citekeyOptions),
+            id: '', // Temporary - will be set at the end
             type: this.typeDropdown.value as (typeof CSL_TYPES)[number],
             title: this.titleInput.value,
             'title-short': this.titleShortInput.value || undefined,
@@ -890,6 +888,12 @@ export class BibliographyModal extends BaseBibliographyModal {
                 citation[fieldName] = value;
             }
         });
+        
+        if (!this.idInput.value) {
+            citation.id = CitekeyGenerator.generate(citation, this.settings.citekeyOptions);
+        } else {
+            citation.id = this.idInput.value;
+        }
         
         return citation;
     }


### PR DESCRIPTION
> Bibliography modal generates the citekey too eagerly (in getFormData) This results in much of the data (in particular fields that only come from additional parsing, such as the year field, which generates/gets added later on, to not be available to be used as variables in the CiteKeyGenerator.generate (as the user would expect). Then since this citekey would now be saved,
>  subsequent input of the user pressing the regenerate function,
> would still result in this eager-generated citekey to continue to be prioritized, even though in debugging, we can see that the 'year' data is now present in the citationData (I believe because there's no distinction that this key was auto-generated vs a manual override from the user?)
> 
> I used similar logic in the citoid function cause it had a similar issue. The imported key would always override, even if the user picked to use the generated key in the import settings. Hopefully that was everything that had this bug

Not totally confident in all my logic here but hopefully it is at least a start :)